### PR TITLE
Githubのスターカウントの表示を消す。

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -53,11 +53,7 @@ class Footer extends React.Component {
             <a
               className="github-button"
               href={this.props.config.repoUrl}
-              data-icon="octicon-star"
-              data-count-href="/facebook/docusaurus/stargazers"
-              data-show-count={true}
-              data-count-aria-label="# stargazers on GitHub"
-              aria-label="Star this project on GitHub">
+              data-icon="octicon-star">
               Star
             </a>
           </div>


### PR DESCRIPTION
## ISSUE

https://github.com/cam-inc/viron/issues/280

ボタンからのリクエスト消したので、上限リミットのエラーもなくなりました。

